### PR TITLE
Add endpoint property to kx.Service

### DIFF
--- a/nodejs/kubernetesx/kx.ts
+++ b/nodejs/kubernetesx/kx.ts
@@ -325,11 +325,11 @@ export class Service extends k8s.core.v1.Service {
             opts);
 
         this.endpoint = this.status.loadBalancer.ingress.apply(ingress => {
-            if (ingress.length > 0) {
+            if (ingress && ingress.length > 0) {
                 return ingress[0].ip || ingress[0].hostname;
             }
             return "";
-        });
+        }) || pulumi.output("");
     }
 }
 

--- a/nodejs/kubernetesx/kx.ts
+++ b/nodejs/kubernetesx/kx.ts
@@ -324,8 +324,11 @@ export class Service extends k8s.core.v1.Service {
             },
             opts);
 
-        this.endpoint = this.status.loadBalancer.ingress[0].apply(ingress => {
-            return ingress.ip || ingress.hostname;
+        this.endpoint = this.status.loadBalancer.ingress.apply(ingress => {
+            if (ingress.length > 0) {
+                return ingress[0].ip || ingress[0].hostname;
+            }
+            return "";
         });
     }
 }

--- a/nodejs/kubernetesx/kx.ts
+++ b/nodejs/kubernetesx/kx.ts
@@ -286,6 +286,12 @@ export class Deployment extends k8s.apps.v1.Deployment {
 }
 
 export class Service extends k8s.core.v1.Service {
+    /**
+     * Endpoint of the Service. This can be either an IP address or a hostname,
+     * depending on the k8s cluster provider.
+     */
+    public endpoint: pulumi.Output<string>;
+
     constructor(name: string, args: types.Service, opts?: pulumi.CustomResourceOptions) {
 
         const spec = pulumi.output(args)
@@ -317,6 +323,10 @@ export class Service extends k8s.core.v1.Service {
                 spec: spec,
             },
             opts);
+
+        this.endpoint = this.status.loadBalancer.ingress[0].apply(ingress => {
+            return ingress.ip || ingress.hostname;
+        });
     }
 }
 


### PR DESCRIPTION
It's common to want the endpoint for a Service, but
it appears in different places depending on the cloud
provider, and is a deeply nested status. Extract this
info and provide a convenience property to access it.

Fixes #36