### PR TITLE
Set portsArg as ports if it's not a PortMap

### DIFF
--- a/nodejs/kubernetesx/kx.ts
+++ b/nodejs/kubernetesx/kx.ts
@@ -292,7 +292,7 @@ export class Service extends k8s.core.v1.Service {
             .apply((args: pulumi.UnwrappedObject<types.Service>) => {
                 const isPortMap = (ports: any): ports is types.PortMap => ports.length === undefined;
 
-                const ports: k8s.types.input.core.v1.ServicePort[] = [];
+                let ports: k8s.types.input.core.v1.ServicePort[] = [];
                 const portsArg = args.spec.ports;
                 if (portsArg) {
                     if (isPortMap(portsArg)) {
@@ -301,7 +301,7 @@ export class Service extends k8s.core.v1.Service {
                             ports.push({name: key, port: value});
                         });
                     } else {
-                        ports.concat(...portsArg);
+                        ports = portsArg;
                     }
                 }
                 return {


### PR DESCRIPTION
Fixes #44 ... I hope

The current version attempts to concatenate the `portsArg` array with the empty `ports` array but misses to reassign the the new array to `ports`.
I just replaced the `concat()` with a simple assignment since the `ports` array will always be empty in this case.