### PR TITLE
Move Service endpoint to a getter

### DIFF
--- a/nodejs/kubernetesx/kx.ts
+++ b/nodejs/kubernetesx/kx.ts
@@ -287,12 +287,6 @@ export class Deployment extends k8s.apps.v1.Deployment {
 }
 
 export class Service extends k8s.core.v1.Service {
-    /**
-     * Endpoint of the Service. This can be either an IP address or a hostname,
-     * depending on the k8s cluster provider.
-     */
-    public endpoint: pulumi.Output<string>;
-
     constructor(name: string, args: types.Service, opts?: pulumi.CustomResourceOptions) {
 
         const spec = pulumi.output(args)
@@ -325,12 +319,20 @@ export class Service extends k8s.core.v1.Service {
             },
             opts);
 
-        this.endpoint = this.status.loadBalancer.ingress.apply(ingress => {
-            if (ingress && ingress.length > 0) {
+    }
+
+    /**
+     * Endpoint of the Service. This can be either an IP address or a hostname,
+     * depending on the k8s cluster provider.
+     */
+    get endpoint(): pulumi.Output<string> {
+        return this.status.loadBalancer.ingress
+            .apply((ingress: k8s.types.output.core.v1.LoadBalancerIngress[]) => {
+            if (ingress.length > 0) {
                 return ingress[0].ip || ingress[0].hostname;
             }
             return "";
-        }) || pulumi.output("");
+        });
     }
 }
 


### PR DESCRIPTION
Rather than setting the endpoint as a property in the
constructor, create an endpoint getter method. Nothing
changes from the user's perspective, but this implementation
works better if the k8s provider is rendering YAML rather
than managing real resources.